### PR TITLE
Fix build: duplicate deployment name

### DIFF
--- a/Services/InvoiceService/infrastructure/containerApp.bicep
+++ b/Services/InvoiceService/infrastructure/containerApp.bicep
@@ -161,7 +161,7 @@ module acrRoleAssignment '../../../core-infrastructure/roleAssignments/acrPull.b
 }
 
 module keyVaultRbac '../../../core-infrastructure/roleAssignments/keyvaultSecretsUser.bicep' = {
-  name: 'InvoiceServiceCosmosDbConnectionString'
+  name: 'allowContainerAppToReadKeyVaultSecrets'
   scope: resourceGroup(coreInfrastructure.resourceGroup)
   params: {
     principalId: containerAppUserIdentity.properties.principalId


### PR DESCRIPTION
Fixing the build - deployment always failed due to a duplicate deployment name in Azure: deployment names should be unique.